### PR TITLE
Update strings.xml (values-fr) - May 20 version

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -179,7 +179,7 @@
     <string name="xiaomi_warning_title">Appareils Xiaomi</string>
     <string name="xiaomi_warning_message">Veuillez activer l\'option \'\'Afficher des fenêtres pop-up pendant que vous parcourez en arrière-plan\'\' dans la section \'\'Autres autorisations\'\' des paramètres de l\'application.\nSinon, vous ne pourrez ouvrir aucune application en tapant sur le widget.</string>
     <string name="action_ignore">Ignorer</string>
-    <string name="action_grant_permission">Aller dans Paramètres</string>
+    <string name="action_grant_permission">Ouvrir les Paramètres</string>
     <string name="settings_title">Paramètres</string>
     <string name="style_header">Style</string>
     <string name="actions_header">Actions</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -126,11 +126,11 @@
     <!-- Glance -->
     <string name="settings_show_next_alarm_title">Prochaine alarme</string>
     <string name="next_alarm_warning">La prochaine alarme semble erronée.\nElle a été définie par %s.</string>
-    <string name="settings_at_a_glance_title">Coup d\'œil</string>
+    <string name="settings_at_a_glance_title">Coups d\'œil</string>
     <string name="settings_show_music_title">Musique en cours de lecture</string>
     <string name="settings_request_notification_access">Nous avons besoin d\'accéder aux notifications pour vérifier la musique en cours de lecture</string>
     <string name="settings_request_fitness_access">Nous avons besoin de quelques autorisations pour obtenir vos nombres de pas quotidiens depuis Google Fit</string>
-    <string name="title_show_glance">Afficher les infos en un coup d\'œil</string>
+    <string name="title_show_glance">Afficher les coups d\'œil</string>
     <string name="description_show_glance_visible">Services activés</string>
     <string name="description_show_glance_not_visible">Services désactivés</string>
     <string name="settings_sort_glance_providers_title">Priorité des sources de données</string>
@@ -142,7 +142,7 @@
     <string name="daily_steps_counter">%d pas jusqu\à présent</string>
     <string name="charging">Batterie en charge</string>
     <string name="providers">Fournisseurs</string>
-    <string name="glance_info">Les infos en un coup d\'œil n\'apparaîtront que si aucun événement n\'est affiché et uniquement lorsque quelques conditions sont vérifiées.</string>
+    <string name="glance_info">Les coups d\'œil n\'apparaîtront que si aucun événement n\'est affiché et uniquement lorsque quelques conditions sont vérifiées.</string>
 
     <!-- Settings -->
     <string name="action_share">Partager</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -140,9 +140,9 @@
     <string name="settings_daily_steps_title">Nombre de pas quotidiens</string>
     <string name="battery_low_warning">Batterie faible</string>
     <string name="daily_steps_counter">%d pas jusqu\à présent</string>
-    <string name="charging">En charge</string>
+    <string name="charging">Batterie en charge</string>
     <string name="providers">Fournisseurs</string>
-    <string name="glance_info">Glance info will show up only when there are no events displayed and only when a few conditions are verified.</string>
+    <string name="glance_info">Les infos en un coup d\'œil n\'apparaîtront que si aucun événement n\'est affiché et uniquement lorsque quelques conditions sont vérifiées.</string>
 
     <!-- Settings -->
     <string name="action_share">Partager</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -177,7 +177,7 @@
     <string name="settings_feedback_subtitle">Ce projet est open-source, n\'hésitez pas à aider</string>
     <string name="settings_feedback_title">Commentaires et suggestions</string>
     <string name="xiaomi_warning_title">Appareils Xiaomi</string>
-    <string name="xiaomi_warning_message">Veuillez activer l\'option "Afficher des fenêtres pop-up pendant que vous parcourez en arrière-plan" dans la section "Autres autorisations" des paramètres de l\'application. Sinon, vous ne pourrez ouvrir aucune application en tapant sur le widget.</string>
+    <string name="xiaomi_warning_message">Veuillez activer l\'option \'\'Afficher des fenêtres pop-up pendant que vous parcourez en arrière-plan\'\' dans la section \'\'Autres autorisations\'\' des paramètres de l\'application.\nSinon, vous ne pourrez ouvrir aucune application en tapant sur le widget.</string>
     <string name="action_ignore">Ignorer</string>
     <string name="action_grant_permission">Aller dans Paramètres</string>
     <string name="settings_title">Paramètres</string>


### PR DESCRIPTION
fdc02b2 :
I translated the Glance explanations (line 145) in French.

56b21be :
I shortened the "title-show-glance" (line 133) because it was oddly long.
It overstepped on a 2nd line, like this:
Afficher les infos en un coup
d'oeil

68b5997 :
I added quotation marks '' and \\n (line 180) for more readability.
Maybe you can change the quoted text to italic if you want.

6e8c6cf : 
I changed the translation to a more logical one.