### PR TITLE
Show & hide all-day events at the right time.

### DIFF
--- a/app/src/main/java/com/tommasoberlose/anotherwidget/db/EventRepository.kt
+++ b/app/src/main/java/com/tommasoberlose/anotherwidget/db/EventRepository.kt
@@ -64,7 +64,7 @@ class EventRepository(val context: Context) {
                 else -> add(Calendar.HOUR, 6)
             }
         }
-        val event = if (nextEvent != null && nextEvent.endDate > now && nextEvent.startDate < limit.timeInMillis) {
+        val event = if (nextEvent != null && nextEvent.endDate > now && nextEvent.startDate <= limit.timeInMillis) {
             nextEvent
         } else {
             val events = getEvents()
@@ -105,7 +105,6 @@ class EventRepository(val context: Context) {
         } else {
             resetNextEventData()
         }
-        UpdatesReceiver.setUpdates(context)
         MainWidget.updateWidget(context)
     }
 
@@ -121,7 +120,6 @@ class EventRepository(val context: Context) {
         } else {
             resetNextEventData()
         }
-        UpdatesReceiver.setUpdates(context)
         MainWidget.updateWidget(context)
     }
 

--- a/app/src/main/java/com/tommasoberlose/anotherwidget/helpers/SettingsStringHelper.kt
+++ b/app/src/main/java/com/tommasoberlose/anotherwidget/helpers/SettingsStringHelper.kt
@@ -88,19 +88,17 @@ object SettingsStringHelper {
     fun getDifferenceText(context: Context, now: Long, start: Long): String {
         val nowDate = DateTime(now)
         val eventDate = DateTime(start)
-
-        var difference = start - now
-        difference += 60 * 1000 - (difference % (60 * 1000))
+        val difference = start - now
 
         when {
             difference <= 0 -> {
                 return ""
             }
-            TimeUnit.MILLISECONDS.toHours(difference) < 1 && Preferences.widgetUpdateFrequency == Constants.WidgetUpdateFrequency.HIGH.rawValue && TimeUnit.MILLISECONDS.toMinutes(difference) > 5 -> {
-                return DateUtils.getRelativeTimeSpanString(start, start - 1000 * 60 * (TimeUnit.MILLISECONDS.toMinutes(difference) - 1 - (TimeUnit.MILLISECONDS.toMinutes(difference) - 1) % 5), DateUtils.MINUTE_IN_MILLIS, DateUtils.FORMAT_ABBREV_RELATIVE).toString()
+            TimeUnit.MILLISECONDS.toHours(difference) < 1 && Preferences.widgetUpdateFrequency == Constants.WidgetUpdateFrequency.HIGH.rawValue && TimeUnit.MILLISECONDS.toMinutes(difference) >= 5 -> {
+                return DateUtils.getRelativeTimeSpanString(start, start - 1000 * 60 * (TimeUnit.MILLISECONDS.toMinutes(difference) - TimeUnit.MILLISECONDS.toMinutes(difference) % 5), DateUtils.MINUTE_IN_MILLIS, DateUtils.FORMAT_ABBREV_RELATIVE).toString()
             }
-            TimeUnit.MILLISECONDS.toHours(difference) < 1 && Preferences.widgetUpdateFrequency == Constants.WidgetUpdateFrequency.DEFAULT.rawValue && TimeUnit.MILLISECONDS.toMinutes(difference) > 15 -> {
-                return DateUtils.getRelativeTimeSpanString(start, start - 1000 * 60 * (TimeUnit.MILLISECONDS.toMinutes(difference) - 1 - (TimeUnit.MILLISECONDS.toMinutes(difference) - 1) % 15), DateUtils.MINUTE_IN_MILLIS, DateUtils.FORMAT_ABBREV_RELATIVE).toString()
+            TimeUnit.MILLISECONDS.toHours(difference) < 1 && Preferences.widgetUpdateFrequency == Constants.WidgetUpdateFrequency.DEFAULT.rawValue && TimeUnit.MILLISECONDS.toMinutes(difference) >= 15 -> {
+                return DateUtils.getRelativeTimeSpanString(start, start - 1000 * 60 * (TimeUnit.MILLISECONDS.toMinutes(difference) - TimeUnit.MILLISECONDS.toMinutes(difference) % 15), DateUtils.MINUTE_IN_MILLIS, DateUtils.FORMAT_ABBREV_RELATIVE).toString()
             }
             TimeUnit.MILLISECONDS.toHours(difference) < 1 && Preferences.widgetUpdateFrequency == Constants.WidgetUpdateFrequency.LOW.rawValue -> {
                 return context.getString(R.string.soon)
@@ -109,22 +107,7 @@ object SettingsStringHelper {
                 return context.getString(R.string.now)
             }
             TimeUnit.MILLISECONDS.toHours(difference) < 12 -> {
-                val minutes =  TimeUnit.MILLISECONDS.toMinutes(difference) - 60 * TimeUnit.MILLISECONDS.toHours(difference)
-                return if (minutes < 1 || minutes > 30) {
-                    DateUtils.getRelativeTimeSpanString(
-                        start,
-                        now - 1000 * 60 * 40,
-                        DateUtils.HOUR_IN_MILLIS,
-                        DateUtils.FORMAT_ABBREV_RELATIVE
-                    ).toString()
-                } else {
-                    DateUtils.getRelativeTimeSpanString(
-                        start,
-                        now,
-                        DateUtils.HOUR_IN_MILLIS,
-                        DateUtils.FORMAT_ABBREV_RELATIVE
-                    ).toString()
-                }
+                return DateUtils.getRelativeTimeSpanString(start, now, DateUtils.HOUR_IN_MILLIS, DateUtils.FORMAT_ABBREV_RELATIVE).toString()
             }
             eventDate.dayOfYear == nowDate.plusDays(1).dayOfYear -> {
                 return String.format("%s", context.getString(R.string.tomorrow))
@@ -142,9 +125,6 @@ object SettingsStringHelper {
     fun getAllDayEventDifferenceText(context: Context, now: Long, start: Long): String {
         val nowDate = DateTime(now)
         val eventDate = DateTime(start)
-
-        var difference = start - now
-        difference += 60 * 1000 - (difference % (60 * 1000))
 
         return when (eventDate.dayOfYear) {
             nowDate.dayOfYear -> {

--- a/app/src/main/java/com/tommasoberlose/anotherwidget/helpers/SettingsStringHelper.kt
+++ b/app/src/main/java/com/tommasoberlose/anotherwidget/helpers/SettingsStringHelper.kt
@@ -99,7 +99,7 @@ object SettingsStringHelper {
             TimeUnit.MILLISECONDS.toHours(difference) < 1 && Preferences.widgetUpdateFrequency == Constants.WidgetUpdateFrequency.HIGH.rawValue && TimeUnit.MILLISECONDS.toMinutes(difference) > 5 -> {
                 return DateUtils.getRelativeTimeSpanString(start, start - 1000 * 60 * (TimeUnit.MILLISECONDS.toMinutes(difference) - 1 - (TimeUnit.MILLISECONDS.toMinutes(difference) - 1) % 5), DateUtils.MINUTE_IN_MILLIS, DateUtils.FORMAT_ABBREV_RELATIVE).toString()
             }
-            TimeUnit.MILLISECONDS.toHours(difference) < 1 && Preferences.widgetUpdateFrequency == Constants.WidgetUpdateFrequency.DEFAULT.rawValue && TimeUnit.MILLISECONDS.toMinutes(difference) > 5 -> {
+            TimeUnit.MILLISECONDS.toHours(difference) < 1 && Preferences.widgetUpdateFrequency == Constants.WidgetUpdateFrequency.DEFAULT.rawValue && TimeUnit.MILLISECONDS.toMinutes(difference) > 15 -> {
                 return DateUtils.getRelativeTimeSpanString(start, start - 1000 * 60 * (TimeUnit.MILLISECONDS.toMinutes(difference) - 1 - (TimeUnit.MILLISECONDS.toMinutes(difference) - 1) % 15), DateUtils.MINUTE_IN_MILLIS, DateUtils.FORMAT_ABBREV_RELATIVE).toString()
             }
             TimeUnit.MILLISECONDS.toHours(difference) < 1 && Preferences.widgetUpdateFrequency == Constants.WidgetUpdateFrequency.LOW.rawValue -> {

--- a/app/src/main/java/com/tommasoberlose/anotherwidget/receivers/NewCalendarEventReceiver.kt
+++ b/app/src/main/java/com/tommasoberlose/anotherwidget/receivers/NewCalendarEventReceiver.kt
@@ -13,8 +13,7 @@ class NewCalendarEventReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         val eventRepository = EventRepository(context)
         when (intent.action) {
-            Intent.ACTION_PROVIDER_CHANGED,
-            Intent.ACTION_TIME_CHANGED -> {
+            Intent.ACTION_PROVIDER_CHANGED -> {
                 CalendarHelper.updateEventList(context)
             }
             Actions.ACTION_GO_TO_NEXT_EVENT -> {

--- a/app/src/main/java/com/tommasoberlose/anotherwidget/receivers/UpdatesReceiver.kt
+++ b/app/src/main/java/com/tommasoberlose/anotherwidget/receivers/UpdatesReceiver.kt
@@ -38,6 +38,7 @@ class UpdatesReceiver : BroadcastReceiver() {
             "com.sec.android.widgetapp.APPWIDGET_RESIZE",
             AlarmManager.ACTION_NEXT_ALARM_CLOCK_CHANGED,
             Actions.ACTION_ALARM_UPDATE,
+            Actions.ACTION_UPDATE_GREETINGS,
             Actions.ACTION_TIME_UPDATE -> {
                 MainWidget.updateWidget(context)
                 if (intent.hasExtra(EVENT_ID)) {
@@ -47,9 +48,6 @@ class UpdatesReceiver : BroadcastReceiver() {
 
             Actions.ACTION_CLEAR_NOTIFICATION -> {
                 ActiveNotificationsHelper.clearLastNotification(context)
-                MainWidget.updateWidget(context)
-            }
-            Actions.ACTION_UPDATE_GREETINGS -> {
                 MainWidget.updateWidget(context)
             }
 
@@ -69,7 +67,25 @@ class UpdatesReceiver : BroadcastReceiver() {
         fun setUpdates(context: Context, eventId: Long? = null) {
             val eventRepository = EventRepository(context)
             if (eventId == null) {
-                removeUpdates(context)
+                with(context.getSystemService(Context.ALARM_SERVICE) as AlarmManager) {
+                    setExact(
+                        AlarmManager.RTC,
+                        Calendar.getInstance().apply {
+                            set(Calendar.MILLISECOND, 0)
+                            set(Calendar.SECOND, 0)
+                            set(Calendar.MINUTE, 0)
+                            set(Calendar.HOUR_OF_DAY, 0)
+                            add(Calendar.DATE, 1)
+                        }.timeInMillis,
+                        PendingIntent.getBroadcast(
+                            context,
+                            0,
+                            Intent(context, UpdatesReceiver::class.java).apply {
+                                action = Actions.ACTION_CALENDAR_UPDATE
+                            },
+                            0)
+                    )
+                }
 
                 eventRepository.getFutureEvents().forEach { event ->
                     setEventUpdate(context, event)
@@ -84,109 +100,80 @@ class UpdatesReceiver : BroadcastReceiver() {
         }
 
         private fun setEventUpdate(context: Context, event: Event) {
-            with(context.getSystemService(Context.ALARM_SERVICE) as AlarmManager) {
-                val now = Calendar.getInstance().apply {
-                    set(Calendar.SECOND, 0)
-                    set(Calendar.MILLISECOND, 0)
-                }
-                val diff = Period(now.timeInMillis, event.startDate)
-                val limit = when (Preferences.showUntil) {
-                    0 -> 1000 * 60 * 60 * 3
-                    1 -> 1000 * 60 * 60 * 6
-                    2 -> 1000 * 60 * 60 * 12
-                    3 -> 1000 * 60 * 60 * 24
-                    4 -> 1000 * 60 * 60 * 24 * 3
-                    5 -> 1000 * 60 * 60 * 24 * 7
-                    6 -> 1000 * 60 * 30
-                    7 -> 1000 * 60 * 60
-                    else -> 1000 * 60 * 60 * 6
-                }
-                if (event.startDate <= limit) {
-                    if (event.startDate > now.timeInMillis) {
-                        // Update the widget every hour till the event
-                        if (diff.hours == 0) {
-                            var minutes = 0
-                            when (Preferences.widgetUpdateFrequency) {
-                                Constants.WidgetUpdateFrequency.DEFAULT.rawValue -> {
-                                    minutes = when {
-                                        diff.minutes > 50 -> 50
-                                        diff.minutes > 30 -> 30
-                                        diff.minutes > 15 -> 15
-                                        else -> 0
-                                    }
-                                }
-                                Constants.WidgetUpdateFrequency.HIGH.rawValue -> {
-                                    minutes = diff.minutes - (diff.minutes % 5)
-                                }
+            val now = Calendar.getInstance().apply {
+                set(Calendar.SECOND, 0)
+                set(Calendar.MILLISECOND, 0)
+            }
+            val diff = Period(now.timeInMillis, event.startDate, org.joda.time.PeriodType.time())
+            val limit = when (Preferences.showUntil) {
+                0 -> 1000 * 60 * 60 * 3
+                1 -> 1000 * 60 * 60 * 6
+                2 -> 1000 * 60 * 60 * 12
+                3 -> 1000 * 60 * 60 * 24
+                4 -> 1000 * 60 * 60 * 24 * 3
+                5 -> 1000 * 60 * 60 * 24 * 7
+                6 -> 1000 * 60 * 30
+                7 -> 1000 * 60 * 60
+                else -> 1000 * 60 * 60 * 6
+            }
+            val fireTime = when {
+                event.startDate <= now.timeInMillis
+                    -> event.endDate
+                event.startDate > now.timeInMillis + limit
+                    -> event.startDate - limit
+                event.allDay
+                    -> event.startDate
+                diff.hours > 12
+                    -> event.startDate - 12 * 1000 * 60 * 60 + 1000 * 60
+                diff.hours > 0
+                    -> event.startDate - diff.hours * 1000 * 60 * 60 + 1000 * 60
+                else
+                    -> event.startDate - 1000 * 60 * when (Preferences.widgetUpdateFrequency) {
+                        Constants.WidgetUpdateFrequency.DEFAULT.rawValue -> {
+                            when {
+                                diff.minutes >= 45 -> 44
+                                diff.minutes >= 30 -> 29
+                                diff.minutes >= 15 -> 14
+                                else -> 0
                             }
-                            setExact(
-                                AlarmManager.RTC,
-                                if (event.startDate - minutes * 1000 * 60 > (now.timeInMillis + 120 * 1000)) event.startDate - 60 * 1000 * minutes else now.timeInMillis + 120000,
-                                PendingIntent.getBroadcast(
-                                    context,
-                                    event.eventID.toInt(),
-                                    Intent(context, UpdatesReceiver::class.java).apply {
-                                        action = Actions.ACTION_TIME_UPDATE
-                                        putExtra(EVENT_ID, event.eventID)
-                                    },
-                                    PendingIntent.FLAG_UPDATE_CURRENT
-                                )
-                            )
-                        } else {
-                            setExact(
-                                AlarmManager.RTC,
-                                event.startDate - diff.hours * 1000 * 60 * 60 + if (diff.minutes > 30) (-30) else (+30),
-                                PendingIntent.getBroadcast(
-                                    context,
-                                    event.eventID.toInt(),
-                                    Intent(context, UpdatesReceiver::class.java).apply {
-                                        action = Actions.ACTION_TIME_UPDATE
-                                        putExtra(EVENT_ID, event.eventID)
-                                    },
-                                    PendingIntent.FLAG_UPDATE_CURRENT
-                                )
-                            )
                         }
-                    } else {
-                        // Update the widget one second after the event is finished
-                        val fireTime =
-                            if (event.endDate > now.timeInMillis + 120 * 1000) event.endDate else now.timeInMillis + 120000
-                        setExact(
-                            AlarmManager.RTC,
-                            fireTime,
-                            PendingIntent.getBroadcast(
-                                context,
-                                event.eventID.toInt(),
-                                Intent(context, UpdatesReceiver::class.java).apply {
-                                    action = Actions.ACTION_TIME_UPDATE
-                                },
-                                0
-                            )
-                        )
+                        Constants.WidgetUpdateFrequency.HIGH.rawValue -> {
+                            when {
+                                diff.minutes >= 5 -> diff.minutes - diff.minutes % 5 - 1
+                                else -> 0
+                            }
+                        }
+                        else -> 0
                     }
-                } else {
-                    setExact(
-                        AlarmManager.RTC,
-                        if (event.startDate - limit > now.timeInMillis + 120 * 1000) event.startDate - limit else now.timeInMillis + 120000,
-                        PendingIntent.getBroadcast(
-                            context,
-                            event.eventID.toInt(),
-                            Intent(context, UpdatesReceiver::class.java).apply {
-                                action = Actions.ACTION_TIME_UPDATE
+            }
+            with(context.getSystemService(Context.ALARM_SERVICE) as AlarmManager) {
+                setExact(
+                    AlarmManager.RTC,
+                    fireTime.coerceAtLeast(now.timeInMillis + 1000 * 60),
+                    PendingIntent.getBroadcast(
+                        context,
+                        event.eventID.toInt(),
+                        Intent(context, UpdatesReceiver::class.java).apply {
+                            action = Actions.ACTION_TIME_UPDATE
+                            if (event.startDate > now.timeInMillis)
                                 putExtra(EVENT_ID, event.eventID)
-                            },
-                            PendingIntent.FLAG_UPDATE_CURRENT
-                        )
+                        },
+                        PendingIntent.FLAG_UPDATE_CURRENT
                     )
-                }
+                )
             }
         }
 
         fun removeUpdates(context: Context) {
             with(context.getSystemService(Context.ALARM_SERVICE) as AlarmManager) {
+                cancel(PendingIntent.getBroadcast(context, 0, Intent(context, UpdatesReceiver::class.java).apply {
+                    action = Actions.ACTION_CALENDAR_UPDATE
+                }, 0))
                 val eventRepository = EventRepository(context)
                 eventRepository.getFutureEvents().forEach {
-                    cancel(PendingIntent.getBroadcast(context, it.eventID.toInt(), Intent(context, UpdatesReceiver::class.java), 0))
+                    cancel(PendingIntent.getBroadcast(context, it.eventID.toInt(), Intent(context, UpdatesReceiver::class.java).apply {
+                        action = Actions.ACTION_TIME_UPDATE
+                    }, 0))
                 }
                 eventRepository.close()
             }

--- a/app/src/main/java/com/tommasoberlose/anotherwidget/receivers/WeatherReceiver.kt
+++ b/app/src/main/java/com/tommasoberlose/anotherwidget/receivers/WeatherReceiver.kt
@@ -22,13 +22,8 @@ class WeatherReceiver : BroadcastReceiver() {
             Intent.ACTION_MY_PACKAGE_REPLACED,
             Intent.ACTION_TIMEZONE_CHANGED,
             Intent.ACTION_LOCALE_CHANGED,
-            Intent.ACTION_TIME_CHANGED -> setUpdates(context)
-
-            Actions.ACTION_WEATHER_UPDATE -> {
-                GlobalScope.launch(Dispatchers.IO) {
-                    WeatherHelper.updateWeather(context)
-                }
-            }
+            Intent.ACTION_TIME_CHANGED,
+            Actions.ACTION_WEATHER_UPDATE -> setUpdates(context)
         }
     }
 
@@ -46,12 +41,14 @@ class WeatherReceiver : BroadcastReceiver() {
                     else -> 60
                 }
                 with(context.getSystemService(Context.ALARM_SERVICE) as AlarmManager) {
-                    setRepeating(
+                    setExact(
                         AlarmManager.RTC,
-                        Calendar.getInstance().timeInMillis,
-                        interval,
+                        System.currentTimeMillis() + interval,
                         PendingIntent.getBroadcast(context, 0, Intent(context, WeatherReceiver::class.java).apply { action = Actions.ACTION_WEATHER_UPDATE }, 0)
                     )
+                }
+                GlobalScope.launch(Dispatchers.IO) {
+                    WeatherHelper.updateWeather(context)
                 }
             }
         }

--- a/app/src/main/java/com/tommasoberlose/anotherwidget/receivers/WeatherReceiver.kt
+++ b/app/src/main/java/com/tommasoberlose/anotherwidget/receivers/WeatherReceiver.kt
@@ -35,8 +35,6 @@ class WeatherReceiver : BroadcastReceiver() {
     companion object {
         private const val MINUTE = 60 * 1000L
         fun setUpdates(context: Context) {
-            removeUpdates(context)
-
             if (Preferences.showWeather) {
                 val interval = MINUTE * when (Preferences.weatherRefreshPeriod) {
                     0 -> 30

--- a/app/src/main/java/com/tommasoberlose/anotherwidget/services/UpdateCalendarService.kt
+++ b/app/src/main/java/com/tommasoberlose/anotherwidget/services/UpdateCalendarService.kt
@@ -88,6 +88,7 @@ class UpdateCalendarService : Service() {
                 ) {
                     eventRepository.resetNextEventData()
                     eventRepository.clearEvents()
+                    Preferences.showEvents = false
                 } else {
                     try {
                         val provider = CalendarProvider(this@UpdateCalendarService)

--- a/app/src/main/java/com/tommasoberlose/anotherwidget/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/tommasoberlose/anotherwidget/ui/activities/MainActivity.kt
@@ -140,6 +140,7 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
 
         if (Preferences.showEvents && !checkGrantedPermission(Manifest.permission.READ_CALENDAR)) {
             Preferences.showEvents = false
+            com.tommasoberlose.anotherwidget.receivers.UpdatesReceiver.removeUpdates(this)
         }
     }
 

--- a/app/src/main/java/com/tommasoberlose/anotherwidget/ui/fragments/tabs/CalendarFragment.kt
+++ b/app/src/main/java/com/tommasoberlose/anotherwidget/ui/fragments/tabs/CalendarFragment.kt
@@ -182,7 +182,7 @@ class CalendarFragment : Fragment() {
 
         binding.showAllDayToggle.setOnCheckedChangeListener { _, isChecked ->
             Preferences.calendarAllDay = isChecked
-            MainWidget.updateWidget(requireContext())
+            updateCalendar()
         }
 
         binding.actionChangeAttendeeFilter.setOnClickListener {
@@ -227,7 +227,7 @@ class CalendarFragment : Fragment() {
 
         binding.showOnlyBusyEventsToggle.setOnCheckedChangeListener { _, isChecked ->
             Preferences.showOnlyBusyEvents = isChecked
-            MainWidget.updateWidget(requireContext())
+            updateCalendar()
         }
 
         binding.actionShowDiffTime.setOnClickListener {
@@ -254,6 +254,7 @@ class CalendarFragment : Fragment() {
                     .addItem(getString(R.string.settings_widget_update_frequency_low), Constants.WidgetUpdateFrequency.LOW.rawValue)
                     .addOnSelectItemListener { value ->
                         Preferences.widgetUpdateFrequency = value
+                        updateCalendar()
                     }.show()
             }
         }

--- a/app/src/main/java/com/tommasoberlose/anotherwidget/ui/fragments/tabs/PreferencesFragment.kt
+++ b/app/src/main/java/com/tommasoberlose/anotherwidget/ui/fragments/tabs/PreferencesFragment.kt
@@ -23,6 +23,7 @@ import com.tommasoberlose.anotherwidget.components.MaterialBottomSheetDialog
 import com.tommasoberlose.anotherwidget.databinding.FragmentPreferencesBinding
 import com.tommasoberlose.anotherwidget.global.Preferences
 import com.tommasoberlose.anotherwidget.helpers.CalendarHelper
+import com.tommasoberlose.anotherwidget.receivers.UpdatesReceiver
 import com.tommasoberlose.anotherwidget.receivers.WeatherReceiver
 import com.tommasoberlose.anotherwidget.ui.activities.MainActivity
 import com.tommasoberlose.anotherwidget.ui.viewmodels.MainViewModel
@@ -123,6 +124,7 @@ class PreferencesFragment : Fragment() {
                 requireCalendarPermission()
             } else {
                 Preferences.showEvents = enabled
+                UpdatesReceiver.removeUpdates(requireContext())
             }
         }
 

--- a/app/src/main/java/com/tommasoberlose/anotherwidget/ui/fragments/tabs/PreferencesFragment.kt
+++ b/app/src/main/java/com/tommasoberlose/anotherwidget/ui/fragments/tabs/PreferencesFragment.kt
@@ -135,6 +135,8 @@ class PreferencesFragment : Fragment() {
         binding.showWeatherSwitch.setOnCheckedChangeListener { _, enabled: Boolean ->
             Preferences.showWeather = enabled
             if (enabled) {
+                Preferences.weatherProviderError = ""
+                Preferences.weatherProviderLocationError = ""
                 WeatherReceiver.setUpdates(requireContext())
             } else {
                 WeatherReceiver.removeUpdates(requireContext())


### PR DESCRIPTION
All-day events should be time zone independent.

For example, if "Show events at least" is set to "1 hour later", then an all-day event should appear at 23:00 of the previous day and disappear at 24:00 of the current day, regardless of the local time zone.

However, it is currently time zone dependent: if the local time zone has a positive offset, e.g., UTC+11, then the all-day event will not appear until 10:00; conversely, if the offset is negative, e.g., UTC-11, then the all-day event will disappear early at 13:00.

Also has a fix for #328.